### PR TITLE
Allow for no particles with PARTICLES set; Adiabatic Expansion ICs

### DIFF
--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -642,6 +642,8 @@ class Grid3D
 
     void Zeldovich_Pancake( struct parameters P );
 
+    void Adiabatic_Expansion( struct parameters P );
+
     void Chemistry_Test( struct parameters P );
 
 

--- a/src/grid/initial_conditions.cpp
+++ b/src/grid/initial_conditions.cpp
@@ -83,6 +83,8 @@ void Grid3D::Set_Initial_Conditions(parameters P) {
     Uniform_Grid();
   } else if (strcmp(P.init, "Zeldovich_Pancake")==0) {
     Zeldovich_Pancake(P);
+  } else if (strcmp(P.init, "Adiabatic_Expansion")==0) {
+    Adiabatic_Expansion(P);
   } else if (strcmp(P.init, "Chemistry_Test")==0) {
     Chemistry_Test(P);
   } else if (strcmp(P.init, "Generate_Cosmological_ICs")==0) {
@@ -1508,6 +1510,87 @@ void Grid3D::Zeldovich_Pancake( struct parameters P ){
   #endif //COSMOLOGY
 
 }
+
+void Grid3D::Adiabatic_Expansion(struct parameters P)
+{
+#ifndef COSMOLOGY
+  chprintf("To run an Adiabatic Expansion test, COSMOLOGY has to be turned ON \n");
+  exit(-1);
+#else
+
+  int i, j, k, id;
+  Real x_pos, y_pos, z_pos;
+  Real H0, h, Omega_M, rho_0, G, z_zeldovich, z_init, x_center, T_init, k_x;
+
+  chprintf("Setting Adiabatic Expansion initial conditions...\n");
+  H0      = P.H0;
+  h       = H0 / 100;
+  Omega_M = P.Omega_M;
+
+  chprintf(" h = %f \n", h);
+  chprintf(" Omega_M = %f \n", Omega_M);
+
+  H0 /= 1000;  //[km/s / kpc]
+  G           = G_COSMO;
+  rho_0       = 3 * H0 * H0 / (8 * M_PI * G) * Omega_M / h / h;
+  z_zeldovich = 1;
+  z_init      = P.Init_redshift;
+  chprintf(" rho_0 = %f \n", rho_0);
+  chprintf(" z_init = %f \n", z_init);
+
+  x_center = H.xdglobal / 2;
+
+  T_init = 100;
+  chprintf(" T initial = %f \n", T_init);
+
+  k_x = 2 * M_PI / H.xdglobal;
+
+  Real dens, vel, temp, U, E, gamma;
+  gamma = P.gamma;
+
+  int index;
+  // set the initial values of the conserved variables
+  for (k = H.n_ghost; k < H.nz - H.n_ghost; k++) {
+    for (j = H.n_ghost; j < H.ny - H.n_ghost; j++) {
+      for (i = H.n_ghost; i < H.nx - H.n_ghost; i++) {
+        id = i + j * H.nx + k * H.nx * H.ny;
+
+        // // get the centered cell positions at (i,j,k)
+        Get_Position(i, j, k, &x_pos, &y_pos, &z_pos);
+
+        // Analytical Initial Conditions
+        //  dens = rho_0 / ( 1 - ( 1 + z_zeldovich ) / ( 1 + z_init ) * cos(
+        //  k_x*( x_pos - x_center )) ); vel = - H0 * ( 1 + z_zeldovich ) /
+        //  sqrt( 1 + z_init ) * sin( k_x*( x_pos - x_center )) / k_x; temp =
+        //  T_init * pow( dens / rho_0, 2./3 ); U = temp / (gamma - 1) / MP * KB
+        //  * 1e-10 * dens; E = 0.5 * dens * vel * vel + U;
+
+        dens = rho_0;
+        U    = T_init/(gamma-1)/MP * KB * 1e-10 * rho_0;
+        vel = - H0 * ( 1 + z_zeldovich ) /  sqrt( 1 + z_init ) * sin( k_x*( x_pos - x_center )) / k_x;
+        vel += - H0 * ( 1 + z_zeldovich ) /  sqrt( 1 + z_init ) / k_x; // Constant velocity
+        //vel = - H0 * ( 1 + z_zeldovich ) /  sqrt( 1 + z_init ) / k_x; // Constant velocity
+        vel  = 0;
+
+        E    = 0.5*dens*vel*vel + U;
+
+        // chprintf( "%f \n", vel );
+        C.density[id]    = dens;
+        C.momentum_x[id] = dens * vel;
+        C.momentum_y[id] = 0;
+        C.momentum_z[id] = 0;
+        C.Energy[id]     = E;
+
+  #ifdef DE
+        C.GasEnergy[id] = U;
+  #endif
+      }
+    }
+  }
+
+#endif  // COSMOLOGY
+}
+
 
 
 

--- a/src/particles/density_CIC_gpu.cu
+++ b/src/particles/density_CIC_gpu.cu
@@ -143,9 +143,13 @@ void Particles_3D::Get_Density_CIC_GPU_function(part_int_t n_local, Real particl
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Get_Density_CIC_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, particle_mass, density_dev, pos_x_dev, pos_y_dev, pos_z_dev, mass_dev, xMin, yMin, zMin, xMax, yMax, zMax, dx, dy, dz, nx_local, ny_local, nz_local, n_ghost_particles_grid );
-  CudaCheckError();
-  cudaDeviceSynchronize();
+
+  // Only runs if there are local particles
+  if (n_local > 0) {
+    hipLaunchKernelGGL(Get_Density_CIC_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, particle_mass, density_dev, pos_x_dev, pos_y_dev, pos_z_dev, mass_dev, xMin, yMin, zMin, xMax, yMax, zMax, dx, dy, dz, nx_local, ny_local, nz_local, n_ghost_particles_grid );
+    CudaCheckError();
+    cudaDeviceSynchronize();
+  }
 
   #if !defined(GRAVITY_GPU)
   //Copy the density from device to host

--- a/src/particles/particles_boundaries_gpu.cu
+++ b/src/particles/particles_boundaries_gpu.cu
@@ -306,6 +306,10 @@ part_int_t Select_Particles_to_Transfer_GPU_function( part_int_t n_local, int si
   // Initialize the number of tranfer particles
   n_transfer_h[0] = 0;
 
+  if (n_local == 0) {
+    return 0;
+  }
+
   hipLaunchKernelGGL( Get_Transfer_Flags_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, side, domainMin, domainMax, pos_d, transfer_flags_d);
   CudaCheckError();
 

--- a/src/particles/particles_dynamics_gpu.cu
+++ b/src/particles/particles_dynamics_gpu.cu
@@ -90,6 +90,10 @@ Real Particles_3D::Calc_Particles_dt_GPU_function( int ngrid, part_int_t n_parti
 
   // printf("%f %f %f \n", dx, dy, dz);
 
+  if (ngrid == 0) {
+    return 0;
+  }
+
   hipLaunchKernelGGL(Calc_Particles_dti_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_particles_local, dx, dy, dz, vel_x, vel_y, vel_z, dti_array_dev );
   CudaCheckError();
 
@@ -150,8 +154,10 @@ void Particles_3D::Advance_Particles_KDK_Step1_GPU_function( part_int_t n_local,
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
-  CudaCheckError();
+  if (n_local > 0) {
+    hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
+    CudaCheckError();
+  }
 
 }
 
@@ -166,8 +172,10 @@ void Particles_3D::Advance_Particles_KDK_Step2_GPU_function( part_int_t n_local,
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
 
-  hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
-  CudaCheckError();
+  if (n_local > 0) {
+    hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
+    CudaCheckError();
+  }
 
 }
 
@@ -249,9 +257,11 @@ void Particles_3D::Advance_Particles_KDK_Step1_Cosmo_GPU_function( part_int_t n_
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
-  CHECK(cudaDeviceSynchronize());
+  if (n_local > 0) {
+    hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
+    CHECK(cudaDeviceSynchronize());
   // CudaCheckError();
+  }
 
 }
 
@@ -266,9 +276,11 @@ void Particles_3D::Advance_Particles_KDK_Step2_Cosmo_GPU_function( part_int_t n_
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
-  CHECK(cudaDeviceSynchronize());
-  // CudaCheckError();
+  if (n_local > 0) {
+    hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
+    CHECK(cudaDeviceSynchronize());
+    // CudaCheckError();
+  }
 
 }
 


### PR DESCRIPTION
Some of the GPU routines for particles expect that each GPU has local particles present. These edits prevent GPU errors from occurring when a GPU does not have local particles. This is required for simulations that use COSMOLOGY & PARTICLES but do not have particles.

I have also added an Adiabatic Expansion ICs routine that initializes a simple adiabatic expansion test based on the Zeldovich pancake ICs.  When the velocities are set to zero in this set of ICs, the uniform gas distribution will just expand (constant comoving density) and cool (T decreases with (1+z)^2/(1+z_init)^2)